### PR TITLE
Enable support for asynchronous reactivity

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -3,6 +3,7 @@ if _G.__DEV__ == nil then
 	_G.__DEV__ = (game and not game:GetService("RunService"):IsStudio()) :: any
 end
 
+local async = require("@self/reactive/async")
 local cleanup = require("@self/reactive/cleanup")
 local create = require("@self/instances/create")
 local derive = require("@self/reactive/derive")
@@ -47,6 +48,7 @@ fluid.root = root
 fluid.source = source
 fluid.untrack = untrack
 fluid.interval = interval
+fluid.async = async
 
 fluid.__SCHEDULER_INTERFACE = scheduler
 

--- a/src/reactive/async.luau
+++ b/src/reactive/async.luau
@@ -1,0 +1,79 @@
+local graph = require("./graph")
+local logging = require("../logging")
+local task = task or require("@lune/task")
+
+type State = "busy" | "ok"
+
+--[[
+async nodes creates a source node for the latest valid value and for the state.
+it also creates a reactive node which spawns a new thread that it runs under it's
+own scope.
+
+when created, the async node gets immediately evaluated similar to an effect.
+unlike an effect though, all evaluations are deferred since we make the assumption
+that async yields every single time.
+]]
+
+local function async<T>(callback: (set: (T) -> ()) -> T): (() -> T, () -> State)
+	local reactive_node: graph.ReactiveNode<any>
+	local value: graph.ReactiveNode<T> = graph.create_reactive_node(
+		graph.assert_stable_parent(),
+		function()
+			graph.defer_node(reactive_node :: any)
+		end :: any,
+		"async"
+	)
+	local state: graph.SourceNode<State> =
+		graph.create_source_node("ok") :: any
+
+	local function set(new: T)
+		graph.update_source_node(value :: any, new)
+	end
+
+	local function update()
+		assert(reactive_node, "reactive node does not exist")
+		graph.update_source_node(state, "busy")
+
+		-- manually set the node to be busy
+		local thread = task.spawn(function()
+			graph.flush_cleanups(value)
+			graph.destroy_owned(value)
+
+			value.state = coroutine.running()
+			local call = graph.run_as(value, callback, set)
+
+			if call.success then
+				set(call.value)
+			else
+				logging.warn(`async effect error: {call.err} {call.trace}`)
+			end
+
+			graph.update_source_node(state, "ok")
+			value.state = "clean"
+		end)
+
+		graph.push_cleanup(reactive_node, function()
+			task.cancel(thread)
+		end)
+	end
+
+	reactive_node = graph.create_reactive_node(
+		graph.assert_stable_parent(),
+		update :: any,
+		"deferred"
+	)
+
+	graph.evaluate_node(reactive_node)
+
+	return function()
+		graph.evaluate_node(reactive_node)
+		graph.push_dependency(value)
+		return value.cached_value
+	end, function()
+		graph.evaluate_node(reactive_node)
+		graph.push_dependency(state)
+		return state.cached_value
+	end
+end
+
+return async

--- a/src/reactive/graph.luau
+++ b/src/reactive/graph.luau
@@ -34,14 +34,15 @@ export type ReactiveNode<T> = {
 	read children: { Node<T> },
 
 	--- Describes the effect to run to compute the result of this node.
-	effect: types.Effect<T>,
+	read effect: types.Effect<T>,
 	read evaluation: "eager" | "deferred" | "lazy" | "dead",
+	last_evaluation: number,
 
 	-- clean: the cached_value result can be used immediately
 	-- dirty: you need to recompute the node
 	-- busy: the node is already being recomputed - throw an error!
 	-- dead: the node is dead
-	state: "clean" | "dirty" | "busy" | "dead",
+	state: "clean" | "dirty" | thread | "dead",
 
 	cached_value: T,
 
@@ -54,7 +55,7 @@ export type ReactiveNode<T> = {
 export type Node<T> = ReactiveNode<T> | StableNode<T>
 
 local pending_eval: { ReactiveNode<unknown> } = {}
-local processing_node: Node<unknown> | false = false
+local processing_node: { [thread]: Node<unknown> } = {}
 local deferred_nodes = {}
 local version = 0
 
@@ -63,17 +64,27 @@ local function bump_version()
 	return version
 end
 
+local function get_scope()
+	return processing_node[coroutine.running()]
+end
+
+local function set_scope(node: Node<any>?)
+	processing_node[coroutine.running()] = node
+end
+
 local function run_as_unsafe<T, U...>(
-	owner: Node<any> | false,
+	owner: Node<any>?,
 	fn: (U...) -> T,
 	...: U...
 ): result.Identity<T, unknown>
-	local previous_processing = processing_node
-	processing_node = owner
+	local previous_processing = get_scope()
+	set_scope(owner)
 	local call = fn(...)
-	processing_node = previous_processing
+	set_scope(previous_processing)
 	return call
 end
+
+local function run_as_async<T, U...>(owner: Node<any>?, fn: (U...) -> T, ...: U...) end
 
 local function defer_node<T>(node: ReactiveNode<T>)
 	if node.state == "dirty" then
@@ -84,14 +95,15 @@ local function defer_node<T>(node: ReactiveNode<T>)
 end
 
 local function push_dependency<T>(node: SourceNode<T> | ReactiveNode<T>)
-	if not (processing_node and processing_node.effect) then
+	local scope = get_scope()
+	if not (scope and scope.effect) then
 		return
 	end
 
-	assert(processing_node ~= node, `node tried to add itself as dependency`)
+	assert(scope ~= node, `node tried to add itself as dependency`)
 
-	table.insert(node.dependents, processing_node)
-	table.insert(processing_node.depending_on, node)
+	table.insert(node.dependents, scope)
+	table.insert(scope.depending_on, node)
 end
 
 local function find_and_swap_pop<T>(t: { T }, v: T)
@@ -211,11 +223,12 @@ local function evaluate_node<T>(
 		push_dependency(node :: SourceNode<T> | ReactiveNode<T>)
 
 		return result.ok(node.cached_value)
-	elseif node.state == "busy" then
+	elseif node.state == "busy" and node.evaluation ~= "async" then
 		return result.fail(
 			`this creates a recursive dependency, which can result in creating a infinite loop.`,
 			debug.traceback(nil, 2)
 		)
+	elseif node.state == "busy" and node.evaluation == "async" then
 	elseif node.state == "dead" then
 		return result.ok(node.cached_value)
 	elseif is_dirty(node :: ReactiveNode<T>) then
@@ -239,6 +252,8 @@ local function invalidate_loop<T>(node: SourceNode<T> | ReactiveNode<T>)
 			table.insert(pending_eval, value)
 		elseif value.evaluation == "deferred" then
 			defer_node(value)
+		elseif value.evaluation == "async" then
+			defer_node(value)
 		elseif value.evaluation == "lazy" then
 			value.state = "dirty"
 		end
@@ -260,6 +275,7 @@ end
 
 local graph = {
 	-- re-exports of local utilities
+	get_scope = get_scope,
 	invalidate = invalidate,
 	destroy = destroy,
 	run_as_unsafe = run_as_unsafe,
@@ -351,10 +367,6 @@ function graph.update_source_node<T>(node: SourceNode<T>, value: T)
 	node.last_evaluation = bump_version()
 	node.cached_value = value
 	invalidate(node)
-end
-
-function graph.get_scope<T>(): Node<T> | false
-	return processing_node
 end
 
 function graph.push_cleanup<T>(scope: Node<T>, cleanup: () -> ())

--- a/src/reactive/graph.luau
+++ b/src/reactive/graph.luau
@@ -308,10 +308,10 @@ local function invalidate<T>(node: SourceNode<T>)
 
 	for _, node in pending_eval do
 		for _, dependent in node.depending_on do
-			run_as_unsafe(false, evaluate_node, dependent)
+			run_as_unsafe(nil, evaluate_node, dependent)
 		end
 
-		run_as_unsafe(false, evaluate_node, node)
+		run_as_unsafe(nil, evaluate_node, node)
 	end
 	table.clear(pending_eval)
 end

--- a/src/reactive/graph.luau
+++ b/src/reactive/graph.luau
@@ -35,12 +35,13 @@ export type ReactiveNode<T> = {
 
 	--- Describes the effect to run to compute the result of this node.
 	read effect: types.Effect<T>,
-	read evaluation: "eager" | "deferred" | "lazy" | "dead",
-	last_evaluation: number,
+	-- async is similar to eager, but unlike eager does not actually update the
+	-- value. this is necessary to support a proper async reactive primitive
+	read evaluation: "eager" | "deferred" | "lazy" | "dead" | "async",
 
 	-- clean: the cached_value result can be used immediately
 	-- dirty: you need to recompute the node
-	-- busy: the node is already being recomputed - throw an error!
+	-- thread: the node is already being recomputed - throw an error!
 	-- dead: the node is dead
 	state: "clean" | "dirty" | thread | "dead",
 
@@ -84,7 +85,17 @@ local function run_as_unsafe<T, U...>(
 	return call
 end
 
-local function run_as_async<T, U...>(owner: Node<any>?, fn: (U...) -> T, ...: U...) end
+local function run_as<T, U...>(
+	owner: Node<any>?,
+	fn: (U...) -> T,
+	...: U...
+): result.Identity<T, unknown>
+	local previous_processing = get_scope()
+	set_scope(owner)
+	local call = result.call(fn, ...)
+	set_scope(previous_processing)
+	return call
+end
 
 local function defer_node<T>(node: ReactiveNode<T>)
 	if node.state == "dirty" then
@@ -164,24 +175,57 @@ local function is_similar(a: unknown, b: unknown): boolean
 end
 
 local function update_node<T>(node: ReactiveNode<T>): result.Identity<T, string>
-	local previous_result = node.cached_value
-	local previous_processing = processing_node
+	local should_reevaluate = #node.depending_on == 0
+	for _, dependency in node.depending_on do
+		-- a dependency was evaluated after this dependency was invalidated
+		if dependency.last_evaluation > node.last_evaluation then
+			should_reevaluate = true
+			break
+		elseif dependency.state == "clean" then
+			continue
+		end
+		-- the dependency is dirty, so we have to reevaluate that dependency
+		if dependency.state == "dirty" then
+			update_node(dependency :: ReactiveNode<T>)
+			if dependency.last_evaluation < node.last_evaluation then
+				continue
+			end
+			should_reevaluate = true
+			break
+		end
+		-- if the dependency is running on the same thread, we have a recursive dependency, otherwise
+		-- it's fine to just recompute the value and have it invalidate later
+		if dependency.state == coroutine.running() then
+			return result.fail(
+				`a recursive dependency has been found, which may result in an infinite loop. this should be unreachable`,
+				debug.traceback(nil, 2)
+			)
+		end
+	end
+
+	if not should_reevaluate then
+		node.state = "clean"
+		return result.ok(node.cached_value)
+	end
 
 	flush_cleanups(node)
 	destroy_owned(node)
 	remove_dependencies(node)
 
-	processing_node = node
-	local call = result.call(node.effect, previous_result)
-	processing_node = previous_processing
+	node.state = coroutine.running()
+	local previous_result = node.cached_value
+	local call = run_as(node, node.effect, previous_result)
+	-- we mark it as clean and bump the evaluation value since we don't
+	-- want to re-run the node even if it errored
+	node.state = "clean"
 
 	if call.success then
-		node.state = "clean" :: any --fixme: typechecking bug
 		push_dependency(node)
 
 		if
 			node.evaluation ~= "eager"
-			and is_similar(previous_result, call.value)
+				and is_similar(previous_result, call.value)
+			or node.evaluation == "async"
 		then
 			return result.ok(node.cached_value)
 		end
@@ -191,7 +235,7 @@ local function update_node<T>(node: ReactiveNode<T>): result.Identity<T, string>
 
 		return result.ok(node.cached_value)
 	else
-		logging.warn(`effect error: {call}`)
+		logging.warn(`effect error: {call.err}`)
 		return result.fail(`effect error: {call.err}`, call.trace)
 	end
 end
@@ -223,12 +267,14 @@ local function evaluate_node<T>(
 		push_dependency(node :: SourceNode<T> | ReactiveNode<T>)
 
 		return result.ok(node.cached_value)
-	elseif node.state == "busy" and node.evaluation ~= "async" then
+	elseif coroutine.running() == node.state then
 		return result.fail(
 			`this creates a recursive dependency, which can result in creating a infinite loop.`,
 			debug.traceback(nil, 2)
 		)
-	elseif node.state == "busy" and node.evaluation == "async" then
+	elseif type(node.state) == "thread" then
+		--todo: should this be allowed?
+		return result.ok(node.cached_value)
 	elseif node.state == "dead" then
 		return result.ok(node.cached_value)
 	elseif is_dirty(node :: ReactiveNode<T>) then
@@ -246,13 +292,10 @@ local function invalidate_loop<T>(node: SourceNode<T> | ReactiveNode<T>)
 
 	for _, value in node.dependents do
 		invalidate_loop(value)
-
-		if value.evaluation == "eager" then -- append it to a queue so it can be evaluated after all nodes are marked dirty.
+		if value.evaluation == "eager" or value.evaluation == "async" then
 			value.state = "dirty"
 			table.insert(pending_eval, value)
 		elseif value.evaluation == "deferred" then
-			defer_node(value)
-		elseif value.evaluation == "async" then
 			defer_node(value)
 		elseif value.evaluation == "lazy" then
 			value.state = "dirty"
@@ -276,11 +319,19 @@ end
 local graph = {
 	-- re-exports of local utilities
 	get_scope = get_scope,
+	set_scope = set_scope,
+
+	flush_cleanups = flush_cleanups,
+	destroy_owned = destroy_owned,
+
+	defer_node = defer_node,
+
 	invalidate = invalidate,
 	destroy = destroy,
 	run_as_unsafe = run_as_unsafe,
 	push_dependency = push_dependency,
 	evaluate_node = evaluate_node,
+	run_as = run_as,
 }
 
 function graph.flush_deferred_nodes()
@@ -298,7 +349,7 @@ end
 function graph.create_reactive_node<T>(
 	parent: StableNode<T> | false,
 	effect: types.Effect<T>,
-	evaluation: "eager" | "deferred" | "lazy",
+	evaluation: "eager" | "deferred" | "lazy" | "async",
 	cached_value: T
 ): ReactiveNode<T>
 	local node: ReactiveNode<T> = {
@@ -373,36 +424,26 @@ function graph.push_cleanup<T>(scope: Node<T>, cleanup: () -> ())
 	table.insert(scope.cleanups, cleanup)
 end
 
-function graph.run_as<T, U...>(
-	owner: Node<any> | false,
-	fn: (U...) -> T,
-	...: U...
-): result.Identity<T, unknown>
-	local previous_processing = processing_node
-	processing_node = owner
-	local call = result.call(fn, ...)
-	processing_node = previous_processing
-	return call
-end
-
 function graph.assert_scope<T>(): ReactiveNode<T> | StableNode<T>
 	return assert(
-		processing_node,
+		get_scope(),
 		"reactive scope error thing, TODO error message"
 	)
 end
 
 function graph.assert_stable_parent<T>(): StableNode<T>
-	if not processing_node then
+	local scope = get_scope()
+
+	if not scope then
 		error(`cannot call {debug.info(2, "n")} without a parent scope`, 2)
-	elseif processing_node.effect ~= false then
+	elseif scope.effect ~= false then
 		error(
 			`cannot call {debug.info(2, "n")} while the parent scope is reactive - this might be a component. consider using untrack() while creating the components.`,
 			2
 		)
 	end
 
-	return processing_node :: StableNode<T>
+	return scope :: StableNode<T>
 end
 
 return graph

--- a/tests/unit_tests/reactive_graph.spec.luau
+++ b/tests/unit_tests/reactive_graph.spec.luau
@@ -1,5 +1,6 @@
 local TEST, CASE, CHECK = require("@vendor/testkit").test()
 local fluid = require("@src/")
+local graph = require("../../src/reactive/graph")
 
 local WEAK_TABLE = { __mode = "kv" }
 
@@ -351,6 +352,118 @@ TEST(
 			num(1)
 
 			CHECK(count == 2)
+		end
+	end)
+)
+
+TEST(
+	"async",
+	wrap_root(function()
+		do
+			CASE("rerun on source change")
+			local a = fluid.source(1)
+			local b = fluid.source(1)
+
+			local count = 0
+			local value = fluid.async(function()
+				a()
+				b()
+				count += 1
+				return count
+			end)
+
+			value()
+			CHECK(count == 1)
+			a(2)
+			value()
+			CHECK(count == 2)
+			b(2)
+			value()
+			CHECK(count == 3)
+		end
+
+		do
+			CASE("rerun on derived source change")
+			local num = fluid.source(0)
+
+			local text = fluid.derive(function()
+				return tostring(num())
+			end)
+
+			local count = 0
+			local value = fluid.async(function()
+				text()
+				count += 1
+				return count
+			end)
+
+			num(1)
+			value()
+			num(2)
+			value()
+			CHECK(count == 3)
+		end
+
+		do
+			CASE("state should show actual state")
+
+			local thread
+			local _, state = fluid.async(function()
+				thread = coroutine.running()
+				coroutine.yield()
+				return 0
+			end)
+
+			CHECK(state() == "busy")
+			coroutine.resume(thread :: any)
+			CHECK(state() == "ok")
+		end
+
+		do
+			CASE("run cleanups if thread is invalidated while yielding")
+			local num = fluid.source(0)
+
+			local did_run = false
+
+			local value = fluid.async(function()
+				num()
+
+				fluid.cleanup(function()
+					did_run = true
+				end)
+
+				coroutine.yield()
+				return 0
+			end)
+
+			value()
+			CHECK(did_run == false)
+			num(1)
+			CHECK(did_run == true)
+		end
+
+		do
+			CASE("dependencies only update if value is updated")
+			local count = 0
+			local thread = coroutine.running()
+
+			local value = fluid.async(function(set)
+				thread = coroutine.running()
+				set(0)
+				coroutine.yield()
+
+				set(1)
+				set(2)
+				return 3
+			end)
+
+			fluid.effect(function()
+				value()
+				count += 1
+			end)
+
+			coroutine.resume(thread)
+			CHECK(count == 4)
 		end
 	end)
 )


### PR DESCRIPTION
Identifies the active node through threads and replaces the existing call-stack reliant system. This allows any reactive node to be asynchronous. To facilitate this change, a new `async` primitive is added to fluid which allows for a reactive primitive that does not block other reactive primitives from running if it yields.

This comes with the drawback that reactive primitives like `effect` and `derive` are also able to yield, blocking other reactive primitives from running on that thread until that finishes, which should be caught by a dedicated no yield pcall.