### PR TITLE
Refactor type definitions and improve function signatures in action and create

### DIFF
--- a/src/instances/action.luau
+++ b/src/instances/action.luau
@@ -1,13 +1,10 @@
 -- exists so we
 local action_metatable_symbol = table.freeze({})
 
-export type Identity = typeof(setmetatable(
-	{} :: {
-		callback: (inst: Instance) -> (),
-		priority: number,
-	},
-	action_metatable_symbol
-))
+export type Indentity = setmetatable<{
+	callback: (inst: Instance) -> (),
+	priority: number,
+}, typeof(action_metatable_symbol)>
 
 local action = {
 	metatable = action_metatable_symbol,
@@ -17,7 +14,10 @@ function action.is_action(action: {} & unknown): boolean
 	return getmetatable(action) :: any == action_metatable_symbol
 end
 
-function action.create(callback: (inst: Instance) -> (), priority: number?)
+function action.create(
+	callback: (inst: Instance) -> (),
+	priority: number?
+): Indentity
 	return setmetatable({
 		callback = callback,
 		priority = priority or 1,

--- a/src/instances/create.luau
+++ b/src/instances/create.luau
@@ -1,8 +1,142 @@
 local bind = require("./bind")
 
+type Instances = {
+	Folder: Folder,
+	BillboardGui: BillboardGui,
+	CanvasGroup: CanvasGroup,
+	Frame: Frame,
+	ImageButton: ImageButton,
+	ImageLabel: ImageLabel,
+	ScreenGui: ScreenGui,
+	ScrollingFrame: ScrollingFrame,
+	SurfaceGui: SurfaceGui,
+	TextBox: TextBox,
+	TextButton: TextButton,
+	TextLabel: TextLabel,
+	UIAspectRatioConstraint: UIAspectRatioConstraint,
+	UICorner: UICorner,
+	UIGradient: UIGradient,
+	UIGridLayout: UIGridLayout,
+	UIListLayout: UIListLayout,
+	UIPadding: UIPadding,
+	UIPageLayout: UIPageLayout,
+	UIScale: UIScale,
+	UISizeConstraint: UISizeConstraint,
+	UIStroke: UIStroke,
+	UIFlexItem: UIFlexItem,
+	UITableLayout: UITableLayout,
+	UITextSizeConstraint: UITextSizeConstraint,
+	VideoFrame: VideoFrame,
+	ViewportFrame: ViewportFrame,
+	UIDragDetector: UIDragDetector,
+	ProximityPrompt: ProximityPrompt,
+	Part: Part,
+	WorldModel: WorldModel,
+	Camera: Camera,
+}
+
+type function GetProperties(instance, instancetype)
+	local properties = types.newtable()
+
+	local function is_signal(value: type): false | type
+		if not (value:is("class") or value:is("table")) then
+			return false
+		end
+
+		for key, value in value:properties() do
+			if
+				key:value() == "Connect"
+				and value.read
+				and value.read.tag == "function"
+			then
+				return value.read
+			end
+		end
+
+		return false
+	end
+
+	local function insert(object)
+		if object:readparent() == nil then
+			return
+		end
+		for key, value in object:properties() do
+			local is_a_signal = is_signal(value.read)
+			if is_a_signal and value.read:is("table") then -- luau-lsp
+				local connect_fn = is_a_signal
+				local params = connect_fn:parameters()
+				if params.head then
+					table.remove(params.head, 1)
+				end
+			elseif
+				value.read:is("function") or value.read:is("intersection")
+			then
+				continue
+			elseif value.write then
+				local type = types.optional(
+					types.unionof(
+						types.newfunction({}, { head = { value.read } }),
+						value.write :: any
+					)
+				)
+
+				properties:setproperty(key :: any, type)
+			end
+		end
+
+		insert(object:readparent())
+	end
+	insert(instance)
+
+	local action = types.newtable({
+		[types.singleton("priority")] = { read = types.number },
+		[types.singleton("callback")] = {
+			read = types.newfunction({ head = { instancetype } }),
+		},
+	} :: any)
+
+	local function_returns_child = types.newfunction()
+	local nested_table_or_function_or_child = types.newtable()
+	local union = types.unionof(
+		instancetype,
+		function_returns_child,
+		nested_table_or_function_or_child
+	)
+
+	nested_table_or_function_or_child:setindexer(types.number, union)
+	function_returns_child:setreturns({ union })
+
+	properties:setindexer(
+		types.number,
+		types.optional(
+			types.unionof(
+				action,
+				instancetype,
+				function_returns_child,
+				properties
+			)
+		)
+	)
+
+	return properties
+end
+
+type function GetInstance(instance_name, instances, instancetype)
+	if not instance_name:is("singleton") then
+		return instancetype
+	end
+
+	for key, value in instances:properties() do
+		if (key :: type):value() == instance_name:value() then
+			return value.read
+		end
+	end
+
+	return instancetype
+end
+
 local function try_create_inst(class_name: string): Instance
-	local success, result =
-		pcall(Instance.new :: (name: string) -> Instance, class_name)
+	local success, result = pcall(Instance.new, class_name)
 	if not success then
 		-- error at the location of the create call
 		error(`Instance class "{class_name}" does not exist`, 3)
@@ -11,11 +145,16 @@ local function try_create_inst(class_name: string): Instance
 	return result
 end
 
-local function create(
-	class_name: string
-): (props: { [unknown]: unknown }) -> Instance
-	return function(props)
-		return (bind(try_create_inst(class_name), props))
+local function create<Class>(
+	class_name: Class
+): (
+	GetProperties<GetInstance<Class, Instances, Instance>, Instance>
+) -> GetInstance<Class, Instances, Instance>
+	return function(props: GetProperties<
+		GetInstance<Class, Instances, Instance>,
+		Instance
+	>): GetInstance<Class, Instances, Instance>
+		return bind(try_create_inst(class_name), props :: any) :: any
 	end
 end
 

--- a/src/reactive/root.luau
+++ b/src/reactive/root.luau
@@ -1,7 +1,7 @@
 local graph = require("./graph")
 local types = require("./types")
 
-local refs: { [graph.Node<any>]: true | nil } = {}
+local refs: { [graph.Node<any>]: true? } = {}
 
 local function root<T...>(fn: (destroy: types.Cleanup) -> T...): (types.Cleanup, T...)
 	local node = graph.create_stable_node(graph.get_scope())


### PR DESCRIPTION
- Fluid.create now autocompletes property names
- action.Identity type now uses the setmetatable type function instead of the hacky typeof(setmetatable({} :: ..., ...))