### PR TITLE
Improve create types

### DIFF
--- a/src/instances/create.luau
+++ b/src/instances/create.luau
@@ -1,3 +1,4 @@
+
 local bind = require("./bind")
 
 type Instances = {
@@ -85,25 +86,18 @@ type UnknownConnectCallback = (...any) -> ()
 type Signal = RBXScriptSignal
 
 type function get_connect(v: type): type?
-	local connect_names = { 
-		types.singleton("Connect"), 
-		types.singleton("connect")
-	}
+	local connect = v:readproperty(types.singleton("Connect"))
 
-	for _, name in connect_names do
-		local connect = v:readproperty(name)
+	if connect and connect:is("function") then
+		local head = connect:parameters().head
 
-		if connect and connect:is("function") then
-			local head = connect:parameters().head
+		if not head then
+			return nil
+		end
+		local callback = head[2]
 
-			if not head then
-				continue
-			end
-			local callback = head[2]
-
-			if callback and callback:is("function") then
-				return callback
-			end
+		if callback and callback:is("function") then
+			return callback
 		end
 	end
 
@@ -111,15 +105,17 @@ type function get_connect(v: type): type?
 end
 
 type function is_signal(v: type): type?
-	if v == Signal and v:is("class") then
+	if v == Signal and v.tag == "class" then
 		return UnknownConnectCallback
-	elseif v:is("table") then
+	-- luau lsp types RBXScriptSignals as tables
+	elseif v.tag == "table" then
 		local connect = get_connect(v)
 
 		if connect then
 			return connect
 		end
 
+		-- i cba to test if this is needed or not
 		local metatable = v:metatable()
 
 		if metatable then
@@ -134,87 +130,91 @@ type function is_signal(v: type): type?
 	return nil
 end
 
-type Action<T> = {
-	read callback: () -> T,
+type instance = Instance
+
+type Action = {
+	read callback: () -> Instance,
 	read priority: number,
 }
 
-type function GetProperties(instance, instancetype)
-	local properties = types.newtable()
+type function GetInstance(class_name: type): type
+	if not class_name:is("singleton") then
+		return instance
+	end
 
-	local function insert(object)
-		if object:readparent() == nil then
-			return
-		end
-		for key, value in object:properties() do
-			local is_a_signal = is_signal(value.read)
-			if is_a_signal and value.read:is("table") then -- luau-lsp
-				local connect_fn = is_a_signal
-				local params = connect_fn:parameters()
-				if params.head then
-					table.remove(params.head, 1)
-				end
-			elseif
-				value.read:is("function") or value.read:is("intersection")
+	return Instances:readproperty(class_name) or instance
+end
+
+-- temp arg for action, because for some reason its not added as a global automatically
+type function GetProperties(class_name: type, action): type
+	local object = GetInstance(class_name)
+	local head_table = {}
+	local args_table =  { head = head_table }
+	local properties = types.newtable()
+	local current = object
+	local empty_table = {}
+
+	local read_only_properties = table.freeze({
+		types.singleton("RobloxLocked"), types.singleton("ClassName"),
+		types.singleton("UniqueId"),
+	})
+
+	while current do
+		for property, value in current:properties() do
+			if table.find(read_only_properties, property) then
+				continue
+			end
+
+			local value_read = value.read :: type
+			local callback = is_signal(value_read)
+
+			if callback then
+				properties:setproperty(property :: any, types.optional(callback))
+			elseif 
+				value_read.tag == "function" or value_read.tag == "intersection"
 			then
 				continue
 			elseif value.write then
-				local type = types.optional(
-					types.unionof(
-						types.newfunction({}, { head = { value.read } }),
-						value.write :: any
-					)
-				)
+				head_table[1] = value_read
 
-				properties:setproperty(key :: any, type)
+				properties:setproperty(
+					property :: any, types.optional(types.unionof(
+						types.newfunction(empty_table :: any, args_table :: any),
+						value.write :: any
+					))
+				)
 			end
 		end
 
-		insert(object:readparent())
+		current = current:readparent()
 	end
-	insert(instance)
-
-	local action = Action(instancetype)
 
 	local function_returns_child = types.newfunction()
 	local nested_table_or_function_or_child = types.newtable()
 	local union = types.unionof(
-		instancetype,
+		instance,
 		function_returns_child,
 		nested_table_or_function_or_child
 	)
 
 	nested_table_or_function_or_child:setindexer(types.number, union)
 	function_returns_child:setreturns({ union })
-
 	properties:setindexer(
 		types.number,
-		types.optional(
-			types.unionof(
-				action,
-				instancetype,
-				function_returns_child,
-				properties
-			)
-		)
+		types.optional(types.unionof(
+			action, instance, properties,
+			function_returns_child
+		))
 	)
 
 	return properties
 end
 
-type function GetInstance(instance_name, instancetype)
-	if not instance_name:is("singleton") then
-		return instancetype
-	end
-
-	return Instances:readproperty(instance_name:value()) or instancetype
-end
-
-local function try_create_inst(class_name: string): Instance
+local function try_create_instance(class_name: string): Instance
 	local success, result = pcall(Instance.new, class_name)
 	if not success then
 		-- error at the location of the create call
-		error(`Instance class "{class_name}" does not exist`, 3)
+		error(result, 3)
 	end
 
 	return result
@@ -222,14 +222,9 @@ end
 
 local function create<Class>(
 	class_name: Class
-): (
-	GetProperties<GetInstance<Class, Instances, Instance>, Instance>
-) -> GetInstance<Class, Instances, Instance>
-	return function(props: GetProperties<
-		GetInstance<Class, Instances, Instance>,
-		Instance
-	>): GetInstance<Class, Instances, Instance>
-		return bind(try_create_inst(class_name), props :: any) :: any
+): (GetProperties<GetInstance<Class>, Action>) -> GetInstance<Class>
+	return function(properties)
+		return bind(try_create_instance(class_name), properties) :: any
 	end
 end
 

--- a/src/instances/create.luau
+++ b/src/instances/create.luau
@@ -234,9 +234,9 @@ local function try_create_instance(class_name: string): Instance
 	return result
 end
 
-local function create<CN>(class_name: CN): (
-	GetProperties<CN>
-) -> GetInstance<CN, Instances>
+local function create<CN>(
+	class_name: CN
+): (GetProperties<CN>) -> GetInstance<CN, Instances>
 	return function(properties)
 		return bind(try_create_instance(class_name), properties) :: any
 	end

--- a/src/instances/create.luau
+++ b/src/instances/create.luau
@@ -204,7 +204,7 @@ type function GetProperties(class_name: type, action): type
 	local union = types.unionof(
 		nested_table_or_function_or_child,
 		function_returns_child,
-		instance,
+		instance
 	)
 
 	nested_table_or_function_or_child:setindexer(types.number, union)

--- a/src/instances/create.luau
+++ b/src/instances/create.luau
@@ -199,12 +199,12 @@ type function GetProperties(class_name: type, action): type
 		current = current:readparent()
 	end
 
-	local function_returns_child = types.newfunction()
 	local nested_table_or_function_or_child = types.newtable()
+	local function_returns_child = types.newfunction()
 	local union = types.unionof(
-		instance,
+		nested_table_or_function_or_child,
 		function_returns_child,
-		nested_table_or_function_or_child
+		instance,
 	)
 
 	nested_table_or_function_or_child:setindexer(types.number, union)
@@ -213,10 +213,10 @@ type function GetProperties(class_name: type, action): type
 		types.number,
 		types.optional(
 			types.unionof(
-				action,
-				instance,
+				function_returns_child,
 				properties,
-				function_returns_child
+				instance,
+				action
 			)
 		)
 	)

--- a/src/instances/create.luau
+++ b/src/instances/create.luau
@@ -1,60 +1,146 @@
 local bind = require("./bind")
 
 type Instances = {
-	Folder: Folder,
+	AudioChannelSplitter: AudioChannelSplitter,
+	AudioPitchShifter: AudioPitchShifter,
+	AudioDeviceOutput: AudioDeviceOutput,
+	AudioChannelMixer: AudioChannelMixer,
+	AudioTextToSpeech: AudioTextToSpeech,
+	AudioDeviceInput: AudioDeviceInput,
+	AudioDistortion: AudioDistortion,
+	AudioCompressor: AudioCompressor,
+	AudioEqualizer: AudioEqualizer,
+	AudioAnalyzer: AudioAnalyzer,
+	AudioListener: AudioListener,
+	AudioRecorder: AudioRecorder,
+	AudioLimiter: AudioLimiter,
+	AudioFlanger: AudioFlanger,
+	AudioEmitter: AudioEmitter,
+	AudioPlayer: AudioPlayer,
+	AudioReverb: AudioReverb,
+	AudioFilter: AudioFilter,
+	ArcHandles: ArcHandles,
+	AudioFader: AudioFader,
+	AudioEcho: AudioEcho,
+	AdGui: AdGui,
+	BoxHandleAdornment: BoxHandleAdornment,
 	BillboardGui: BillboardGui,
+	BlurEffect: BlurEffect,
+	CylinderHandleAdornment: CylinderHandleAdornment,
+	ConeHandleAdornment: ConeHandleAdornment,
 	CanvasGroup: CanvasGroup,
+	Camera: Camera,
+	DialogChoice: DialogChoice,
+	DragDetector: DragDetector,
+	Dialog: Dialog,
+	Folder: Folder,
 	Frame: Frame,
+	Highlight: Highlight,
+	Handles: Handles,
+	ImageHandLeAdornment: ImageHandleAdornment,
 	ImageButton: ImageButton,
 	ImageLabel: ImageLabel,
-	ScreenGui: ScreenGui,
-	ScrollingFrame: ScrollingFrame,
-	SurfaceGui: SurfaceGui,
-	TextBox: TextBox,
-	TextButton: TextButton,
-	TextLabel: TextLabel,
-	UIAspectRatioConstraint: UIAspectRatioConstraint,
-	UICorner: UICorner,
-	UIGradient: UIGradient,
-	UIGridLayout: UIGridLayout,
-	UIListLayout: UIListLayout,
-	UIPadding: UIPadding,
-	UIPageLayout: UIPageLayout,
-	UIScale: UIScale,
-	UISizeConstraint: UISizeConstraint,
-	UIStroke: UIStroke,
-	UIFlexItem: UIFlexItem,
-	UITableLayout: UITableLayout,
-	UITextSizeConstraint: UITextSizeConstraint,
-	VideoFrame: VideoFrame,
-	ViewportFrame: ViewportFrame,
-	UIDragDetector: UIDragDetector,
+	LineHandleAdornment: LineHandleAdornment,
 	ProximityPrompt: ProximityPrompt,
 	Part: Part,
+	SphereHandLeAdornment: SphereHandleAdornment,
+	SelectionSphere: SelectionSphere,
+	ScrollingFrame: ScrollingFrame,
+	SelectionBox: SelectionBox,
+	StyleDerive: StyleDerive,
+	SurfaceGui: SurfaceGui,
+	StyleSheet: StyleSheet,
+	SoundGroup: SoundGroup,
+	StyleLink: StyleLink,
+	ScreenGui: ScreenGui,
+	StyleBase: StyleBase,
+	StyleRule: StyleRule,
+	Sound: Sound,
+	TextButton: TextButton,
+	TextLabel: TextLabel,
+	TextBox: TextBox,
+	UIAspectRatioConstraint: UIAspectRatioConstraint,
+	UITextSizeConstraint: UITextSizeConstraint,
+	UISizeConstraint: UISizeConstraint,
+	UIDragDetector: UIDragDetector,
+	UITableLayout: UITableLayout,
+	UIPageLayout: UIPageLayout,
+	UIGridLayout: UIGridLayout,
+	UIListLayout: UIListLayout,
+	UIGradient: UIGradient,
+	UIFlexItem: UIFlexItem,
+	UIPadding: UIPadding,
+	UIStroke: UIStroke,
+	UICorner: UICorner,
+	UIScale: UIScale,
+	ViewportFrame: ViewportFrame,
+	VideoFrame: VideoFrame,
+	WireframeHandleAdornment: WireframeHandleAdornment,
 	WorldModel: WorldModel,
-	Camera: Camera,
+	Wire: Wire,
+}
+
+type UnknownConnectCallback = (...any) -> ()
+
+type Signal = RBXScriptSignal
+
+type function get_connect(v: type): type?
+	local connect_names = { 
+		types.singleton("Connect"), 
+		types.singleton("connect")
+	}
+
+	for _, name in connect_names do
+		local connect = v:readproperty(name)
+
+		if connect and connect:is("function") then
+			local head = connect:parameters().head
+
+			if not head then
+				continue
+			end
+			local callback = head[2]
+
+			if callback and callback:is("function") then
+				return callback
+			end
+		end
+	end
+
+	return nil
+end
+
+type function is_signal(v: type): type?
+	if v == Signal and v:is("class") then
+		return UnknownConnectCallback
+	elseif v:is("table") then
+		local connect = get_connect(v)
+
+		if connect then
+			return connect
+		end
+
+		local metatable = v:metatable()
+
+		if metatable then
+			connect = get_connect(metatable)
+
+			if connect then
+				return connect
+			end
+		end
+	end
+
+	return nil
+end
+
+type Action<T> = {
+	read callback: () -> T,
+	read priority: number,
 }
 
 type function GetProperties(instance, instancetype)
 	local properties = types.newtable()
-
-	local function is_signal(value: type): false | type
-		if not (value:is("class") or value:is("table")) then
-			return false
-		end
-
-		for key, value in value:properties() do
-			if
-				key:value() == "Connect"
-				and value.read
-				and value.read.tag == "function"
-			then
-				return value.read
-			end
-		end
-
-		return false
-	end
 
 	local function insert(object)
 		if object:readparent() == nil then
@@ -88,12 +174,7 @@ type function GetProperties(instance, instancetype)
 	end
 	insert(instance)
 
-	local action = types.newtable({
-		[types.singleton("priority")] = { read = types.number },
-		[types.singleton("callback")] = {
-			read = types.newfunction({ head = { instancetype } }),
-		},
-	} :: any)
+	local action = Action(instancetype)
 
 	local function_returns_child = types.newfunction()
 	local nested_table_or_function_or_child = types.newtable()
@@ -121,18 +202,12 @@ type function GetProperties(instance, instancetype)
 	return properties
 end
 
-type function GetInstance(instance_name, instances, instancetype)
+type function GetInstance(instance_name, instancetype)
 	if not instance_name:is("singleton") then
 		return instancetype
 	end
 
-	for key, value in instances:properties() do
-		if (key :: type):value() == instance_name:value() then
-			return value.read
-		end
-	end
-
-	return instancetype
+	return Instances:readproperty(instance_name:value()) or instancetype
 end
 
 local function try_create_inst(class_name: string): Instance

--- a/src/instances/create.luau
+++ b/src/instances/create.luau
@@ -136,17 +136,17 @@ type Action = {
 	read priority: number,
 }
 
-type function GetInstance(class_name: type): type
+type function GetInstance(class_name: type, instances: type): type
 	if not class_name:is("singleton") then
 		return instance
 	end
 
-	return Instances:readproperty(class_name) or instance
+	return instances:readproperty(class_name) or instance
 end
 
 -- temp arg for action, because for some reason its not added as a global automatically
-type function GetProperties(class_name: type, action): type
-	local object = GetInstance(class_name)
+type function GetProperties(class_name: type): type
+	local object = GetInstance(class_name, Instances)
 	local head_table = {}
 	local args_table = { head = head_table }
 	local properties = types.newtable()
@@ -216,7 +216,7 @@ type function GetProperties(class_name: type, action): type
 				function_returns_child,
 				properties,
 				instance,
-				action
+				Action
 			)
 		)
 	)
@@ -234,9 +234,9 @@ local function try_create_instance(class_name: string): Instance
 	return result
 end
 
-local function create<Class>(class_name: Class): (
-	GetProperties<GetInstance<Class>, Action>
-) -> GetInstance<Class>
+local function create<CN>(class_name: CN): (
+	GetProperties<CN>
+) -> GetInstance<CN, Instances>
 	return function(properties)
 		return bind(try_create_instance(class_name), properties) :: any
 	end

--- a/src/instances/create.luau
+++ b/src/instances/create.luau
@@ -1,4 +1,3 @@
-
 local bind = require("./bind")
 
 type Instances = {
@@ -149,13 +148,14 @@ end
 type function GetProperties(class_name: type, action): type
 	local object = GetInstance(class_name)
 	local head_table = {}
-	local args_table =  { head = head_table }
+	local args_table = { head = head_table }
 	local properties = types.newtable()
 	local current = object
 	local empty_table = {}
 
 	local read_only_properties = table.freeze({
-		types.singleton("RobloxLocked"), types.singleton("ClassName"),
+		types.singleton("RobloxLocked"),
+		types.singleton("ClassName"),
 		types.singleton("UniqueId"),
 	})
 
@@ -169,19 +169,29 @@ type function GetProperties(class_name: type, action): type
 			local callback = is_signal(value_read)
 
 			if callback then
-				properties:setproperty(property :: any, types.optional(callback))
-			elseif 
-				value_read.tag == "function" or value_read.tag == "intersection"
+				properties:setproperty(
+					property :: any,
+					types.optional(callback)
+				)
+			elseif
+				value_read.tag == "function"
+				or value_read.tag == "intersection"
 			then
 				continue
 			elseif value.write then
 				head_table[1] = value_read
 
 				properties:setproperty(
-					property :: any, types.optional(types.unionof(
-						types.newfunction(empty_table :: any, args_table :: any),
-						value.write :: any
-					))
+					property :: any,
+					types.optional(
+						types.unionof(
+							types.newfunction(
+								empty_table :: any,
+								args_table :: any
+							),
+							value.write :: any
+						)
+					)
 				)
 			end
 		end
@@ -201,10 +211,14 @@ type function GetProperties(class_name: type, action): type
 	function_returns_child:setreturns({ union })
 	properties:setindexer(
 		types.number,
-		types.optional(types.unionof(
-			action, instance, properties,
-			function_returns_child
-		))
+		types.optional(
+			types.unionof(
+				action,
+				instance,
+				properties,
+				function_returns_child
+			)
+		)
 	)
 
 	return properties
@@ -220,9 +234,9 @@ local function try_create_instance(class_name: string): Instance
 	return result
 end
 
-local function create<Class>(
-	class_name: Class
-): (GetProperties<GetInstance<Class>, Action>) -> GetInstance<Class>
+local function create<Class>(class_name: Class): (
+	GetProperties<GetInstance<Class>, Action>
+) -> GetInstance<Class>
 	return function(properties)
 		return bind(try_create_instance(class_name), properties) :: any
 	end


### PR DESCRIPTION
* Properly handles `RBXScriptSignal` being a class like it is in studio, as only `:is` can be used in user code on class type instances alongside the other reading methods besides `:properties()`
* Removes recursive function calls
* Read only properties like `UniqueId` are now not included by GetProperties
* Added more instances to the Instances table (basically every instance that someone may want to create)
* Alphabetically sorted Instances table
* Include signals in the table given by GetProperties, with the respective callback for that signal being the value
* Make GetInstance use readproperty instead of having it iterate through the Instances table