### PR TITLE
Implement internal node groups

### DIFF
--- a/.lune/test.luau
+++ b/.lune/test.luau
@@ -1,1 +1,3 @@
+_G.__DEV__ = true
+
 require("@tests/").unit_tests()

--- a/src/anim/lerp.luau
+++ b/src/anim/lerp.luau
@@ -44,6 +44,7 @@ local lerp_functions: { [string]: (a: any, b: any, t: number) -> any } = {
 local lerp = {}
 
 function lerp.create<T>(goal: types.UsedAs<T>, takes: types.UsedAs<number>)
+	graph.set_group(graph.new_group("lerp"))
 	local output = graph.create_source_node(read(goal))
 
 	local function effect()
@@ -59,6 +60,7 @@ function lerp.create<T>(goal: types.UsedAs<T>, takes: types.UsedAs<number>)
 	end
 
 	graph.create_reactive_node(graph.assert_stable_parent(), effect, "deferred")
+	graph.clear_group()
 
 	return function()
 		graph.push_dependency(output)

--- a/src/anim/spring/spring_file.luau
+++ b/src/anim/spring/spring_file.luau
@@ -150,6 +150,7 @@ function spring_file.create<T>(
 	damping: number
 ): (() -> T, (SpringControls<T>) -> ())
 	-- initialize spring state early so we can reference it in the effect for the output node
+	graph.set_group(graph.new_group("spring"))
 
 	local output = graph.create_source_node(read(input))
 
@@ -195,6 +196,7 @@ function spring_file.create<T>(
 	)
 
 	graph.evaluate_node(input_node)
+	graph.clear_group()
 
 	return function()
 		graph.push_dependency(output)

--- a/src/instances/bind.luau
+++ b/src/instances/bind.luau
@@ -52,12 +52,14 @@ local function get_property(inst: Instance, property: string): any
 end
 
 local function bind_property<T>(inst: Instance, property: string, value: types.Readable<T>)
+	graph.set_group(graph.new_group(`bind "{property}"`))
 	local property_node = graph.create_reactive_node(graph.assert_stable_parent(), function()
 		set_property(inst, property, value())
 		return nil
 	end, "deferred", nil)
 
 	graph.evaluate_node(property_node)
+	graph.clear_group()
 end
 
 local function bind_event(inst: Instance, event_name: string, func: <T...>(T...) -> ())
@@ -70,6 +72,7 @@ local function bind_event(inst: Instance, event_name: string, func: <T...>(T...)
 end
 
 local function bind_reactive_child(inst: Instance, func: () -> { Instance } | Instance)
+	graph.set_group(graph.new_group("children"))
 	local stable_node = graph.assert_stable_parent()
 
 	local property_node = graph.create_reactive_node(
@@ -121,6 +124,7 @@ local function bind_reactive_child(inst: Instance, func: () -> { Instance } | In
 	)
 
 	graph.evaluate_node(property_node)
+	graph.clear_group()
 end
 
 local function evaluate(

--- a/src/instances/for_keys.luau
+++ b/src/instances/for_keys.luau
@@ -1,12 +1,17 @@
 local graph = require("../reactive/graph")
 local read = require("../utils/read")
-local types = require("../reactive/types")
 local scheduler = require("../scheduler")
+local types = require("../reactive/types")
 
 local function indexes<K, VI, VO>(
 	input: types.UsedAs<{ [K]: VI }>,
-	transform: (() -> VI, K, active: types.Readable<boolean>) -> (VO, number?)
+	transform: (
+		() -> VI,
+		K,
+		active: types.Readable<boolean>
+	) -> (VO, number?)
 ): () -> { VO }
+	graph.set_group(graph.new_group("for_keys"))
 	local parent = graph.assert_stable_parent()
 	local child_parent = graph.create_stable_node(parent)
 
@@ -113,6 +118,7 @@ local function indexes<K, VI, VO>(
 	end
 
 	reactive_node.effect = update
+	graph.clear_group()
 
 	return function()
 		local result = graph.evaluate_node(reactive_node)

--- a/src/instances/for_values.luau
+++ b/src/instances/for_values.luau
@@ -1,12 +1,17 @@
 local graph = require("../reactive/graph")
 local read = require("../utils/read")
-local types = require("../reactive/types")
 local scheduler = require("../scheduler")
+local types = require("../reactive/types")
 
 local function values<V, KI, KO>(
 	input: types.UsedAs<{ [KI]: V }>,
-	transform: (value: V, key: () -> KI, active: types.Readable<boolean>) -> (KO, number?)
+	transform: (
+		value: V,
+		key: () -> KI,
+		active: types.Readable<boolean>
+	) -> (KO, number?)
 ): () -> { KO }
+	graph.set_group(graph.new_group("for_values"))
 	local parent = graph.assert_stable_parent()
 	local child_parent = graph.create_stable_node(parent)
 
@@ -120,6 +125,7 @@ local function values<V, KI, KO>(
 	end
 
 	reactive_node.effect = update
+	graph.clear_group()
 
 	return function()
 		local result = graph.evaluate_node(reactive_node)

--- a/src/reactive/async.luau
+++ b/src/reactive/async.luau
@@ -15,6 +15,7 @@ that async yields every single time.
 ]]
 
 local function async<T>(callback: (set: (T) -> ()) -> T): (() -> T, () -> State)
+	graph.set_group(graph.new_group("async"))
 	local reactive_node: graph.ReactiveNode<any>
 	local value: graph.ReactiveNode<T> = graph.create_reactive_node(
 		graph.assert_stable_parent(),
@@ -60,6 +61,7 @@ local function async<T>(callback: (set: (T) -> ()) -> T): (() -> T, () -> State)
 		graph.create_reactive_node(graph.assert_stable_parent(), update :: any, "deferred")
 
 	graph.evaluate_node(reactive_node)
+	graph.clear_group()
 
 	return function()
 		graph.evaluate_node(reactive_node)

--- a/src/reactive/deferred.luau
+++ b/src/reactive/deferred.luau
@@ -2,6 +2,7 @@ local graph = require("./graph")
 local types = require("./types")
 
 local function deferred<T>(callback: types.Effect<T>, initial_value: T)
+	graph.set_group(graph.new_group("deferred"))
 	local node = graph.create_reactive_node(
 		graph.assert_stable_parent(),
 		callback,
@@ -10,6 +11,7 @@ local function deferred<T>(callback: types.Effect<T>, initial_value: T)
 	)
 
 	graph.evaluate_node(node)
+	graph.clear_group()
 end
 
 -- cover effect(function() end) and effect(function() return 1 end, 1)

--- a/src/reactive/derive.luau
+++ b/src/reactive/derive.luau
@@ -2,6 +2,7 @@ local graph = require("./graph")
 local types = require("./types")
 
 local function derive<T>(source: types.Effect<T>): types.Readable<T>
+	graph.set_group(graph.new_group("derive"))
 	local node = graph.create_reactive_node(graph.assert_stable_parent(), source, "lazy")
 
 	local function evaluate()
@@ -10,6 +11,7 @@ local function derive<T>(source: types.Effect<T>): types.Readable<T>
 		return if result.success then result.value else error(result, 0)
 	end
 
+	graph.clear_group()
 	return evaluate
 end
 

--- a/src/reactive/effect.luau
+++ b/src/reactive/effect.luau
@@ -2,9 +2,11 @@ local graph = require("./graph")
 local types = require("./types")
 
 local function effect<T>(callback: types.Effect<T>, initial_value: T)
+	graph.set_group(graph.new_group("effect"))
 	local node =
 		graph.create_reactive_node(graph.assert_stable_parent(), callback, "eager", initial_value)
 
+	graph.clear_group()
 	graph.evaluate_node(node)
 end
 

--- a/src/reactive/graph.luau
+++ b/src/reactive/graph.luau
@@ -92,7 +92,7 @@ local function set_scope(node: Node<any>?)
 end
 
 local function new_group(name: string): NodeGroup
-	if dev_mode then
+	if not dev_mode then
 		return nil :: any
 	end
 
@@ -102,7 +102,7 @@ local function new_group(name: string): NodeGroup
 end
 
 local function set_group(group: NodeGroup)
-	if dev_mode then
+	if not dev_mode then
 		return
 	end
 
@@ -110,7 +110,7 @@ local function set_group(group: NodeGroup)
 end
 
 local function clear_group()
-	if dev_mode then
+	if not dev_mode then
 		return
 	end
 

--- a/src/reactive/graph.luau
+++ b/src/reactive/graph.luau
@@ -3,6 +3,17 @@ local result = require("../result")
 local scheduler = require("../scheduler")
 local types = require("./types")
 
+local dev_mode = _G.__DEV__ == true
+
+-- groups are an internal way of organizing nodes within developer mode to enhance
+-- and add additonial debugging information for the user. nodes, should NEVER be part of multiple groups!
+export type NodeGroup = {
+	read name: string,
+
+	-- nodes that are part of the group
+	[number]: Node<unknown> | SourceNode<unknown>,
+}
+
 export type SourceNode<T> = {
 	last_evaluation: number,
 	read state: "clean",
@@ -59,7 +70,12 @@ export type Node<T> = ReactiveNode<T> | StableNode<T>
 local graph
 local pending_eval: { ReactiveNode<unknown> } = {}
 local processing_node: { [thread]: Node<unknown> } = {}
+local node_groups: { [Node<unknown> | SourceNode<unknown>]: NodeGroup } = setmetatable(
+	{},
+	{ __mode = "k" }
+)
 local deferred_nodes = {}
+local current_group: NodeGroup? = nil
 local version = 0
 
 local function bump_version()
@@ -75,11 +91,37 @@ local function set_scope(node: Node<any>?)
 	processing_node[coroutine.running()] = node
 end
 
-local function run_as_unsafe<T..., U...>(
-	owner: Node<any>?,
-	fn: (U...) -> T...,
-	...: U...
-): T...
+local function new_group(name: string): NodeGroup
+	if dev_mode then
+		return nil :: any
+	end
+
+	return setmetatable({
+		name = name,
+	}, { __mode = "v" }) -- __mode doesn't collect garbage on strings
+end
+
+local function set_group(group: NodeGroup)
+	if dev_mode then
+		return
+	end
+
+	current_group = group
+end
+
+local function clear_group()
+	if dev_mode then
+		return
+	end
+
+	current_group = nil
+end
+
+local function get_group(node: Node<unknown> | SourceNode<unknown>): NodeGroup?
+	return node_groups[node]
+end
+
+local function run_as_unsafe<T..., U...>(owner: Node<any>?, fn: (U...) -> T..., ...: U...): T...
 	local previous_processing = get_scope()
 	set_scope(owner)
 	local a, b = fn(...)
@@ -337,6 +379,11 @@ graph = {
 	push_dependency = push_dependency,
 	evaluate_node = evaluate_node,
 	run_as = run_as,
+
+	new_group = new_group,
+	set_group = set_group,
+	clear_group = clear_group,
+	get_group = get_group,
 }
 
 function graph.flush_deferred_nodes()
@@ -372,6 +419,11 @@ function graph.create_reactive_node<T>(
 		cleanups = {},
 	}
 
+	if current_group then
+		table.insert(current_group, node)
+		node_groups[node] = current_group
+	end
+
 	if parent then
 		table.insert(parent.children, node)
 	end
@@ -397,6 +449,11 @@ function graph.create_stable_node<T>(parent: Node<T> | false)
 		cleanups = {},
 	}
 
+	if current_group then
+		table.insert(current_group, node)
+		node_groups[node] = current_group
+	end
+
 	if parent then
 		table.insert(parent.children, node)
 	end
@@ -412,6 +469,11 @@ function graph.create_source_node<T>(value: T): SourceNode<T>
 		state = "clean",
 		dependents = {},
 	}
+
+	if current_group then
+		table.insert(current_group, node)
+		node_groups[node] = current_group
+	end
 
 	return node
 end

--- a/src/reactive/root.luau
+++ b/src/reactive/root.luau
@@ -4,6 +4,7 @@ local types = require("./types")
 local refs: { [graph.Node<any>]: true? } = {}
 
 local function root<T...>(fn: (destroy: types.Cleanup) -> T...): (types.Cleanup, T...)
+	graph.set_group(graph.new_group("root"))
 	local node = graph.create_stable_node(graph.get_scope())
 
 	-- prevent gc of root node
@@ -28,6 +29,7 @@ local function root<T...>(fn: (destroy: types.Cleanup) -> T...): (types.Cleanup,
 		destroy()
 		error(result)
 	end
+	graph.clear_group()
 
 	-- luau type issue w generic type packs
 	return destroy, unpack(results) :: any

--- a/src/reactive/source.luau
+++ b/src/reactive/source.luau
@@ -11,7 +11,9 @@ local function get_argument_from<T>(...: T): (boolean, T)
 end
 
 local function source<T>(initial_value: T): types.Source<T>
+	graph.set_group(graph.new_group("source"))
 	local node = graph.create_source_node(initial_value)
+	graph.clear_group()
 
 	-- This uses varargs so we can tell the difference between f(), f(nil), and f(value)
 	return function(...: T): T

--- a/src/utils/interval.luau
+++ b/src/utils/interval.luau
@@ -4,8 +4,10 @@ local scheduler = require("../scheduler")
 local function interval<T>(func: (dt: number) -> T, hz: number?)
 	local scope = graph.assert_stable_parent()
 
+	graph.set_group(graph.new_group("interval"))
 	local node = graph.create_source_node(func(0))
 	local last_eval = 0
+	graph.clear_group()
 
 	local function on_render(dt: number)
 		if hz ~= nil then

--- a/src/utils/show_delay.luau
+++ b/src/utils/show_delay.luau
@@ -1,5 +1,5 @@
-local types = require("../reactive/types")
 local switch_delay = require("./switch_delay")
+local types = require("../reactive/types")
 
 local function show<T, U>(
 	condition: () -> any,
@@ -8,12 +8,14 @@ local function show<T, U>(
 ): () -> { T | U }
 	return switch_delay(function()
 		return not not condition()
-	end) {
+	end)({
 		[true] = truthy,
-		[false] = falsy :: any
-	}
+		[false] = falsy :: any,
+	})
 end
 
-return show ::
-	& (<T>(condition: () -> any, truthy: types.Readable<T>) -> () -> { T })
-	& <T, U>(condition: () -> any, truthy: types.Readable<T>, falsy: types.Readable<U>) -> () -> { T | U }
+return show :: & (<T>(condition: () -> any, truthy: types.Readable<T>) -> () -> { T }) & <T, U>(
+	condition: () -> any,
+	truthy: types.Readable<T>,
+	falsy: types.Readable<U>
+) -> () -> { T | U }

--- a/src/utils/switch_delay.luau
+++ b/src/utils/switch_delay.luau
@@ -1,8 +1,8 @@
 local derive = require("../reactive/derive")
 local graph = require("../reactive/graph")
+local result = require("../result")
 local scheduler = require("../scheduler")
 local types = require("../reactive/types")
-local result = require("../result")
 
 type Condition<T> = (types.Readable<boolean>) -> (T, number?)
 
@@ -16,7 +16,10 @@ type SwitchGraph<Result> = {
 }
 
 local function switch<Key, Result>(condition: () -> Key)
-	return function(options: { [Key]: (types.Readable<boolean>) -> (Result, number?) }): () -> { Result }
+	return function(
+		options: { [Key]: (types.Readable<boolean>) -> (Result, number?) }
+	): () -> { Result }
+		graph.set_group(graph.new_group("switch_delay"))
 		local parent_node = graph.assert_stable_parent()
 		-- allows us to force an update on the reactive node
 		local update_counter = graph.create_source_node(0)
@@ -54,13 +57,18 @@ local function switch<Key, Result>(condition: () -> Key)
 			end
 
 			-- previous effect isn't the same as active effect, so destroy previous effect
-			if previous_effect and not p.threads[previous_effect] and p.scopes[previous_effect] then
+			if
+				previous_effect
+				and not p.threads[previous_effect]
+				and p.scopes[previous_effect]
+			then
 				local delay_by = p.delay_by[previous_effect]
 
 				graph.update_source_node(p.active_nodes[previous_effect], false)
 
 				if delay_by then
-					p.threads[previous_effect] = scheduler.delay(delay_by, destroy_delayed, p, previous_effect)
+					p.threads[previous_effect] =
+						scheduler.delay(delay_by, destroy_delayed, p, previous_effect)
 				else
 					destroy(p, previous_effect)
 				end
@@ -108,8 +116,10 @@ local function switch<Key, Result>(condition: () -> Key)
 			result_values = {},
 		})
 
+		graph.clear_group()
 		return function()
-			local result: result.Identity<SwitchGraph<Result>, unknown> = graph.evaluate_node(reactive)
+			local result: result.Identity<SwitchGraph<Result>, unknown> =
+				graph.evaluate_node(reactive)
 
 			if result.success then
 				local values = {}

--- a/src/utils/tags.luau
+++ b/src/utils/tags.luau
@@ -12,17 +12,18 @@ end
 
 local function tags(tags: { string | () -> string? }): action.Identity
 	return action.create(function(instance)
+		graph.set_group(graph.new_group("bind tags"))
 		for _, tag in tags do
 			if typeof(tag) == "string" then
 				bind_tag(instance, tag)
 				continue
 			end
-
 			graph.create_reactive_node(graph.assert_stable_parent(), function(): nil
 				local current = tag()
 				return if current then bind_tag(instance, current) else nil
 			end, "deferred", nil)
 		end
+		graph.clear_group()
 	end)
 end
 

--- a/tests/unit_tests/reactive_graph.spec.luau
+++ b/tests/unit_tests/reactive_graph.spec.luau
@@ -1144,4 +1144,19 @@ TEST(
 	end)
 )
 
+TEST(
+	"groups",
+	wrap_root(function()
+		do
+			CASE("groups exist")
+			fluid.graph.set_group(fluid.graph.new_group("test"))
+
+			local node = fluid.graph.create_stable_node(false)
+			CHECK(fluid.graph.get_group(node) ~= nil)
+
+			fluid.graph.clear_group()
+		end
+	end)
+)
+
 return nil


### PR DESCRIPTION
Implements grouping for nodes which should make it slightly easier for developers to write debuggers as we now name reactive nodes more appropriately.