### PR TITLE
Prevent duplicated cleanup threads for delayed keys/values

### DIFF
--- a/src/instances/for_keys.luau
+++ b/src/instances/for_keys.luau
@@ -52,7 +52,7 @@ local function indexes<K, VI, VO>(
 
 		-- remove unused values
 		for key in input_nodes do
-			if input[key] then
+			if input[key] or destruction_threads[key] then
 				continue
 			end
 			local node = output_active[key]

--- a/src/instances/for_values.luau
+++ b/src/instances/for_values.luau
@@ -58,7 +58,7 @@ local function values<V, KI, KO>(
 
 		-- remove unused values
 		for value in input_nodes do
-			if reversed[value] then
+			if reversed[value] or destruction_threads[value] then
 				continue
 			end
 


### PR DESCRIPTION
e.g of when a duplicated thread is created:
```
set value A to 1
set value A to nil
set value B to 1 -> this creates another cleanup thread for A
``